### PR TITLE
Assorted improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,11 @@
             <version>3.0</version>
         </dependency>
         <dependency>
+			      <groupId>org.freemarker</groupId>
+				    <artifactId>freemarker</artifactId>
+				    <version>2.3.23</version>
+				</dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.12</version>

--- a/src/main/java/spark/debug/DebugScreenExample.java
+++ b/src/main/java/spark/debug/DebugScreenExample.java
@@ -14,7 +14,7 @@ public class DebugScreenExample {
             request.session().attribute("example-session-attr", "example-session-attr-content");
         });
         get("*", (req, res) -> {
-            throw new Exception("Exceptions everywhere!");
+          return Integer.parseInt("lol");
         });
         enableDebugScreen(); //just add this to your project to enable the debug screen
     }

--- a/src/main/resources/debugscreen.ftl
+++ b/src/main/resources/debugscreen.ftl
@@ -39,7 +39,7 @@
                 </div>
             </header>
             <div id="exc-btns">
-                <button id="copy-button" class="clipboard" data-clipboard-text="${plain_exception}" title="Copy exception details to clipabord">
+                <button id="copy-button" class="clipboard" data-clipboard-text="${plain_exception}" title="Copy exception details to clipboard">
                     Copy stacktrace
                 </button>
                 <button id="google-button" data-google-query="<#list name as namePart>${namePart}<#if !namePart?is_last>+</#if></#list>" title="Google this exception">

--- a/src/main/resources/public/js/main.js
+++ b/src/main/resources/public/js/main.js
@@ -26,6 +26,10 @@ Zepto(function ($) {
 
     $frameContainer.on('click', '.frame', function () {
         var $this = $(this);
+        setActiveFrame($this);
+    });
+
+    function setActiveFrame($this) {
         var id = /frame\-line\-([\d]*)/.exec($this.attr('id'))[1];
         var $codeFrame = $('#frame-code-' + id);
 
@@ -43,7 +47,7 @@ Zepto(function ($) {
 
             $detailsContainer.scrollTop(0);
         }
-    });
+    }
 
     var clipboard = new Clipboard('.clipboard');
     var showTooltip = function (elem, msg) {
@@ -109,4 +113,13 @@ Zepto(function ($) {
         $.get(this.href);
     });
 
+    // Set the first frame for which a code snippet could be found (if any) to be visible.
+    // That frame will most likely be the most immediately relevant to the user.
+    $(document).ready(function() {
+      var codeFrames = $('.frame.has-code');
+
+      if (codeFrames.length > 0) {
+        setActiveFrame($(codeFrames[0]));
+      }
+    });
 });


### PR DESCRIPTION
- Updated pom.xml to fix build issue in Eclipse.
- DebugScreen now sets HTTP 500 (Internal Server Error) so that ajax requests will fail
  correctly when the screen is enabled.
- DebugScreen now displays the causing exception, not the one passed in. Leads to more relevant errors in more cases.
- DebugScreen now supports handling Throwables as well as Exceptions (via handleThrowable).
- The first stack frame that has a code snippet (if any) will be shown initially as it will likely contain the most relevant information for the user.
