### PR TITLE
Force output to string

### DIFF
--- a/src/main/resources/debugscreen.ftl
+++ b/src/main/resources/debugscreen.ftl
@@ -104,7 +104,7 @@
                                     <#list data?keys as k>
                                         <tr>
                                             <td><div>${k}</div></td>
-                                            <td><div>${data[k]}</div></td>
+                                            <td><div>${data[k]?string}</div></td>
                                         </tr>
                                     </#list>
                                 </table>


### PR DESCRIPTION
Forcing the output to string where freemarker can see it as bool, eg. "true" or "false", forcing it to a string seems safe at the location in the template. This will solve the issue I encountered (issue #5 ). However a review might be good ;), haven't gone to all possible values that can happen at that point.